### PR TITLE
Update 2020-04-24-action-state-value-function-bellman-equation-optima…

### DIFF
--- a/_posts/2020-04-24-action-state-value-function-bellman-equation-optimal-functions-deep-reinforcement-learning-series.md
+++ b/_posts/2020-04-24-action-state-value-function-bellman-equation-optimal-functions-deep-reinforcement-learning-series.md
@@ -143,7 +143,7 @@ $$\mathop{\mathbb{E}}_{\pi} [\gamma \ \Sigma_{k=0}^{\infty}{\gamma^{k}r_{t+k+2}}
 
 The first expectation:
 
-$$\mathop{\mathbb{E}}_{\pi} [r_{t+1} \ \vert \ S_t = s, A_t = a]  = \Sigma_{s'} \ p(s', r, \ \vert \ s, a) \ r(s, a, s') \ $$
+$$\mathop{\mathbb{E}}_{\pi} [r_{t+1} \ \vert \ S_t = s, A_t = a]  = \Sigma_{s'} \ p(s', r, \ \vert \ s, a) \ r(s, a, s')$$
 
 The second expectation:
 


### PR DESCRIPTION
…l-functions-deep-reinforcement-learning-series.md

Removed a backslash which was breaking LaTeX math mode (result visible here: https://gurpreet-ai.github.io/action-state-value-function-bellman-equation-optimal-functions-deep-reinforcement-learning-series/)